### PR TITLE
Added possibility to use Page Access Token

### DIFF
--- a/src/FbFeed.php
+++ b/src/FbFeed.php
@@ -17,6 +17,7 @@ class FbFeed {
     private $keyword = null;
     private $limit = 100; // all of it
     private $fields = 'id,message,created_time,from,permalink_url,full_picture';
+    private $access_token = null;
 
     /**
      * FbFeed constructor.
@@ -26,6 +27,7 @@ class FbFeed {
         $this->secret_key =  getenv('FB_SECRET_KEY');
         $this->app_id = getenv('FB_APP_ID');
         $this->page_name = getenv('FB_PAGENAME');
+        $this->access_token = getenv('FB_ACCESS_TOKEN');
     }
 
 
@@ -55,6 +57,15 @@ class FbFeed {
      */
     function setSecretKey ($secret_key) {
         $this->secret_key = $secret_key;
+        return $this;
+    }
+    
+    /**
+     * @param $access_token
+     * @return $this
+     */
+    function setAccessToken ($access_token) {
+        $this->access_token = $access_token;
         return $this;
     }
 
@@ -104,16 +115,16 @@ class FbFeed {
             return $this->returnFailed('Page Name is needed');
         }
 
-        if (!$this->app_id) {
+        if (!$this->app_id&&!$this->access_token) {
             return $this->returnFailed('Facebook App ID is needed. Please refer to https://developers.facebook.com');
         }
 
-        if (!$this->secret_key) {
+        if (!$this->secret_key&&!$this->access_token) {
             return $this->returnFailed('Facebook Secret Key is needed. Please refer to https://developers.facebook.com');
         }
-
+        
         // this is how to construct access token using secret key and app id
-        $accessToken = $this->app_id . '|' . $this->secret_key;
+        $accessToken = $this->access_token ? $this->access_token : $this->app_id . '|' . $this->secret_key;
 
         // make request as stated in https://developers.facebook.com/docs/graph-api/using-graph-api
         $url = 'https://graph.facebook.com/' . $this->page_name . '/feed';


### PR DESCRIPTION
Code didn't work for me in the case getting the latest posts from my own Facebook page. Found out that i had to review my app (public content access or manage pages permissions), but there seems to be a much easier and quicker way to get this working:

<https://sujipthapa.co/blog/generating-never-expiring-facebook-page-access-token>

To use this i had to set the (page) access token directly. Modified the code to allow this optionally (and omnit app ID and secret key if the access token is set).

Again, this is only working for pages that are owned by the user/developer account.
Furthermore i'm not sure, if that works on other (not owned) pages anymore as Facebook is very strict in the review process (had two failed attempts so far).